### PR TITLE
Pablo-Leon conference talk slides available on GitHub

### DIFF
--- a/Talks/2024-11-22_leon_rodenas_docker_shiny.md
+++ b/Talks/2024-11-22_leon_rodenas_docker_shiny.md
@@ -1,0 +1,16 @@
+## Deploying a Shiny app with Docker in a Raspberry Pi (Pablo Leon-Rodenas)
+
+### Links
+
+- [Slides](https://pablo-source.github.io/RPySOC_24_Docker_Shiny.html#/title-slide)
+
+- [Code](https://github.com/Pablo-source/Pablo-source.github.io/blob/main/RPySOC_24_Docker_Shiny.qmd)
+
+- [Talk Repo – RPYSOC 2024 Docker_Shiny](https://github.com/Pablo-source/RPYSOC_2024_Docker_Shiny)
+
+
+### Abstract
+
+This project describes how to create a Shiny app Deployed inside a Docker Container running on a Raspberry pi.
+
+The aim of this project is to show a example on how to create Shiny apps in R deploying them in Docker to share and manage them using Docker containers.


### PR DESCRIPTION
Hi NHS-R Community/ Anya Ferguson. 

Please find @anyaferguson in this Pull request the .md file I created called "2024-11-22_leon_rodenas_docker_shiny.md". After forking the main "conference-2024" repo, then using Git Clone I cloned it on my local machine  using this command on the terminal "git clone git@github.com:Pablo-source/conference-2024.git" and  created the markdown document below that is the main file included in this Pull request "2024-11-22_leon_rondenas_docker_shiny.md". 

Please  let me know if I should amend anything. 

I included in the .md file the links to the slides, the code used to create the Quarto presentation and also the main GitHub repo with a thorough explanation of the process of Deploying a Shiny App using Docker.

KR

Pablo. 