### PR TITLE
Add slides for 'Unleashing the power of pathway simulation' Talk 

### DIFF
--- a/Talks/2024-11-22_rosser_power_of_pathway_simulation.md
+++ b/Talks/2024-11-22_rosser_power_of_pathway_simulation.md
@@ -4,7 +4,7 @@
 
 - [Slides](https://bergam0t.github.io/nhsr_conf_2024_pres_des/)
 
-- [Code](https://bergam0t.github.io/nhsr_conf_2024_pres_des/)
+- [Code](https://github.com/Bergam0t/nhsr_conf_2024_pres_des)
 
 ### Abstract
 

--- a/Talks/2024-11-22_rosser_power_of_pathway_simulation.md
+++ b/Talks/2024-11-22_rosser_power_of_pathway_simulation.md
@@ -1,0 +1,35 @@
+## Unleashing the power of pathway simulation (Sammi Rosser)
+
+### Links
+
+- [Slides](https://bergam0t.github.io/nhsr_conf_2024_pres_des/)
+
+- [Code](https://bergam0t.github.io/nhsr_conf_2024_pres_des/)
+
+### Abstract
+
+Discrete Event Simulation (DES) is a powerful tool for modelling queuing problems, allowing complex questions about pathways and resourcing to be explored before making costly and potentially risky changes to health services. 
+However, there are barriers to its adoption: dedicated commercial software is prohibitively expensive, while free code-based open-source options are powerful and flexible but can be difficult to get started with and often lack the ability to clearly and engagingly visualise the model’s inner workings for stakeholders.
+
+This talk will provide a brief introduction to DES before covering a range of efforts that are underway within our team to overcome these problems and make DES an accessible modelling approachfor everyone working in healthcare: 
+
+- building a repository of adaptable models for a variety of common pathways in healthcare
+- writing a free ebook in Quarto to give people a clear way to learn
+- building interactive tools to teach the underlying concepts to non-technical audiences
+- and creating a simple yet flexible visualisation package to generate animations showing the flow of entities within the simulated system, helping to make the models more understandable
+
+While the work primarily revolves around the SimPy package in Python, several elements have potential to be adapted for use with Python’s ciw package or R’s simmer package. 
+With the first version of the book available, several example models created, and the visualisation package due to be released in late 2024, now is a great time to start exploring the world of pathway simulation! 
+
+### Key Links
+
+- [HSMA Book of DES](https://hsma-programme.github.io/hsma6_des_book/)
+- [HSMA DES Training](https://hsma-programme.github.io/hsma_site/hsma_content/modules/current_module_details/2_des.html)
+- [HSMA Book of Streamlit - DES Project](https://bergam0t.github.io/streamlit_book/p1_0_des_code.html)
+- [HSMA Web App Training - session 7c covers building the DES frontend](https://hsma-programme.github.io/hsma_site/hsma_content/modules/current_module_details/7_git_and_web_development.html)
+- [DES Playground](https://hsma-programme.github.io/Teaching_DES_Concepts_Streamlit/)
+- [vidigi](https://github.com/Bergam0t/vidigi) DES visualisation package
+
+[![Add me on LinkedIn](https://img.shields.io/badge/linkedin-%230077B5.svg?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/sammijaderosser/)
+
+[![Follow me on GitHub](https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)](https://github.com/Bergam0t)


### PR DESCRIPTION
Added link to slides and code for pathway simulation talk from the Friday (2024-11-22_rosser_power_of_pathway_simulation.md).

I've included a couple of extra links to the bottom of the template to make it easier to find key links from the presentation - happy to remove those if preferred!